### PR TITLE
feat: add ability to disable minifier (`options.minify`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module.exports = {
 + `parserOpts`: Configure babel with special parser options.
 + `babel`: Pass in a custom babel-core instead. `require("babel-core")`
 + `babili`: Pass in a custom babili preset instead - `require("babel-preset-babili")`.
++ `minify`: Disable minifier (for use in development only)
 ``
 
 <h2 align="center">Why</h2>

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,10 @@ module.exports = class BabiliPlugin {
   apply(compiler) {
     const {babiliOpts, options} = this;
 
+    if (options.minify === false) {
+      return;
+    }
+
     const jsregex = options.test || /\.js($|\?)/i;
     const commentsRegex = typeof options.comments === "undefined"
       ? /@preserve|@licen(s|c)e/


### PR DESCRIPTION
**What**
Add an option that can disable this plugin

**Why**
In some cases, a project may not want to enable the minifier. While it's possible to use things like [Webpack Blocks](https://github.com/andywer/webpack-blocks/tree/master/packages/babel6) or [WebpackConfig](https://github.com/webpack-config) to conditionally include plugins or to have multiple config files, for simple projects it is often easier to have a bit of config in the `webpack.config` itself. A prime example of this is the Webpack define plugin which is commonly used with `"process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV)`. This PR allows for an override to simply not register the plugin.

**How**
Rather than disable the babili options, this PR prevents the Webpack plugin from registering in the first place if the `minify: false` override is set.