### PR TITLE
fix: import `babel` as an ES2015 Module

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,10 +7,8 @@
         "targets": {
           "node": "4.3"
         },
-        "include": [
-          "transform-async-to-generator"
-        ],
         "exclude": [
+          "transform-async-to-generator",
           "transform-regenerator"
         ]
       }
@@ -27,7 +25,17 @@
   "env": {
     "test": {
       "presets": [
-        "env"
+        [
+          "env",
+          {
+            "exclude": [
+              "transform-regenerator"
+            ],
+            "include": [
+              "transform-async-to-generator"
+            ]
+          }
+        ]
       ],
       "plugins": [
         "transform-object-rest-spread"

--- a/.babelrc
+++ b/.babelrc
@@ -7,8 +7,10 @@
         "targets": {
           "node": "4.3"
         },
+        "include": [
+          "transform-async-to-generator"
+        ],
         "exclude": [
-          "transform-async-to-generator",
           "transform-regenerator"
         ]
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable multiline-ternary, no-void */
-import babel from 'babel-core';
+import { transform } from 'babel-core';
 import babelPresetMinify from 'babel-preset-minify';
 import { SourceMapSource, RawSource } from 'webpack-sources';
 
@@ -13,7 +13,7 @@ export default class BabelMinifyPlugin {
       parserOpts: pluginOpts.parserOpts || {},
       minifyPreset: pluginOpts.minifyPreset || babelPresetMinify,
       minifyOpts,
-      babel: pluginOpts.babel || babel,
+      babel: pluginOpts.babel || { transform },
       comments: getDefault(pluginOpts.comments, /^\**!|@preserve|@license|@cc_on/),
       // compiler.options.devtool overrides options.sourceMap if NOT set
       // so we set it to void 0 as the default value

--- a/test/babel-minify-plugin.test.js
+++ b/test/babel-minify-plugin.test.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import webpack from 'webpack';
 import rimraf from 'rimraf';
 import { SourceMapConsumer } from 'source-map';
+import { transform } from 'babel-core';
 import BabelMinifyPlugin from '../src/index';
 
 const buildDir = path.join(__dirname, 'build');
@@ -17,14 +18,16 @@ describe('babel-minify-webpack-plugin', () => {
     rimraf.sync(buildDir);
   });
 
-  describe('sourcemaps', () => {
-    beforeAll((done) => {
-      run({
-        devtool: 'sourcemap',
-      })
-        .then(() => done())
-        .catch(err => done(err));
+  describe('works', () => {
+    it('fine', async () => {
+      await run();
+      const output = getFile('bundle.js');
+      expect(isMinified(output)).toBe(true);
     });
+  });
+
+  describe('sourcemaps', () => {
+    beforeAll(async () => run({ devtool: 'sourcemap' }));
 
     it('should have sourcemaps with correct filenames', () => {
       const src = sources().map(s => s.replace('webpack:///', ''));
@@ -39,45 +42,54 @@ describe('babel-minify-webpack-plugin', () => {
       rimraf.sync(buildDir);
     });
 
-    it('should disable sourcemap when devtool is not present', (done) => {
-      run({
-        devtool: undefined,
-      })
-        .then(() => {
-          expect(isExists(path.join(buildDir, 'bundle.js'))).toEqual(true);
-          expect(isExists(path.join(buildDir, 'bundle.js.map'))).toEqual(false);
-          done();
-        })
-        .catch(e => done(e));
+    it('should disable sourcemap when devtool is not present', async () => {
+      await run({ devtool: undefined });
+      expect(isExists(path.join(buildDir, 'bundle.js'))).toEqual(true);
+      expect(isExists(path.join(buildDir, 'bundle.js.map'))).toEqual(false);
     });
 
-    it('should accept a regex as comments test', (done) => {
-      run({
-        comments: /@preserve/,
-      })
-        .then(() => {
-          const output = getFile('bundle.js');
-          expect(output).toMatch(preserveRegexp);
-          expect(output).toNotMatch(licenseRegexp);
-          done();
-        })
-        .catch(e => done(e));
+    it('should accept a regex as comments test', async () => {
+      await run({ comments: /@preserve/ });
+      const output = getFile('bundle.js');
+      expect(output).toMatch(preserveRegexp);
+      expect(output).not.toMatch(licenseRegexp);
     });
 
-    it('should accept function as comments test', (done) => {
-      run({
+    it('should accept function as comments test', async () => {
+      await run({
         comments(comment) {
           return comment.includes('Hmm');
         },
-      })
-        .then(() => {
-          const output = getFile('bundle.js');
-          expect(output).toNotMatch(preserveRegexp);
-          expect(output).toNotMatch(licenseRegexp);
-          expect(output).toMatch(hmmRegexp);
-          done();
-        })
-        .catch(e => done(e));
+      });
+
+      const output = getFile('bundle.js');
+      expect(output).not.toMatch(preserveRegexp);
+      expect(output).not.toMatch(licenseRegexp);
+      expect(output).toMatch(hmmRegexp);
+    });
+
+    it('should accept a custom babel', async () => {
+      const mockOutput = '-🎉-THIS-IS-AN-INVALID-MOCK-CODE-🎉-';
+      const mockTransform = jest.fn(() => {
+        return { code: mockOutput };
+      });
+      await run({ babel: { transform: mockTransform } });
+      const output = getFile('bundle.js');
+      expect(output).toBe(mockOutput);
+    });
+
+    it('should accept a custom minifyPreset', async () => {
+      const mockPlugin = jest.fn(() => {
+        return { visitor: {} };
+      });
+      const mockPreset = jest.fn(() => {
+        return {
+          plugins: [mockPlugin],
+        };
+      });
+      await run({ minifyPreset: mockPreset });
+      expect(mockPreset.mock.calls.length).toBe(1);
+      expect(mockPlugin.mock.calls.length).toBe(1);
     });
   });
 });
@@ -111,9 +123,7 @@ function getFile(file) {
   return fs.readFileSync(path.join(buildDir, file)).toString();
 }
 
-function getConfig(opts) {
-  if (typeof opts === 'undefined') opts = {};
-
+function getConfig(opts = {}) {
   return {
     entry: path.join(__dirname, 'resources/app.js'),
     output: {
@@ -123,4 +133,30 @@ function getConfig(opts) {
     plugins: [new BabelMinifyPlugin({}, opts)],
     devtool: opts.devtool ? opts.devtool : undefined,
   };
+}
+
+function isMinified(code) {
+  let minified = true;
+
+  // traverse the code and find if there are any unmangled names
+  // this acts as a cue to find if a code is minified
+  transform(code, {
+    plugins: [
+      () => {
+        return {
+          visitor: {
+            ReferencedIdentifier(path) {
+              const { name } = path.node;
+              if (name.length > 2 && ['undefined', 'arguments'].indexOf(name) < 0 && !path.scope.hasGlobal(name)) {
+                minified = false;
+                path.stop();
+              }
+            },
+          },
+        };
+      },
+    ],
+  });
+
+  return minified;
 }

--- a/test/resources/app.js
+++ b/test/resources/app.js
@@ -1,12 +1,12 @@
 /* @license MIT */
-const a = require('./a');
-const b = require('./b');
+const moduleA = require('./a');
+const moduleB = require('./b');
 
 /* Hmm... */
 if (process.env.NODE_ENV === 'production') {
-  run(a, b);
+  run(moduleA, moduleB);
 } else {
-  run(b, a);
+  run(moduleB, moduleA);
 }
 
 /* @preserve Run function */


### PR DESCRIPTION
Previously, this plugin had require statements. So

```js
const babel = require("babel-core")
```

worked. But because we are using ES6 modules and babel-core doesn't
have any default export, we cannot do that anylonger.

Other changes:

+ Refactor tests to use async functions
+ Add test to ensure the minification works
+ Add overrides tests

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
