### PR TITLE
ci(travis): apply webpack-defaults - update node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
-      node_js: 4.3
+      node_js: 4.7
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
-      node_js: 4.7
+      node_js: 4.8
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
@@ -33,7 +33,7 @@ jobs:
       node_js: 8
       env: WEBPACK_VERSION=canary JOB_PART=test
 before_install:
-  - 'if [[ `npm -v` != 5* ]]; then npm i -g npm@latest; fi'
+  - 'if [[ `npm -v` != 5* ]]; then npm i -g npm@^5.0.0; fi'
   - nvm --version
   - node --version
   - npm --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,12 +18,12 @@ build: 'off'
 matrix:
   fast_finish: true
 install:
-  - 'ps: Install-Product node $env:nodejs_version x64'
+  - ps: Install-Product node $env:nodejs_version x64
   - npm i -g npm@latest
   - npm install
 before_test:
-  - 'cmd: npm install webpack@%webpack_version%'
+  - cmd: npm install webpack@%webpack_version%
 test_script:
   - node --version
   - npm --version
-  - 'cmd: npm run appveyor:%job_part%'
+  - cmd: npm run appveyor:%job_part%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,12 @@ build: 'off'
 matrix:
   fast_finish: true
 install:
-  - ps: Install-Product node $env:nodejs_version x64
+  - 'ps: Install-Product node $env:nodejs_version x64'
+  - npm i -g npm@latest
   - npm install
 before_test:
-  - cmd: npm install webpack@%webpack_version%
+  - 'cmd: npm install webpack@%webpack_version%'
 test_script:
   - node --version
   - npm --version
-  - cmd: npm run appveyor:%job_part%
+  - 'cmd: npm run appveyor:%job_part%'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - nodejs_version: '6'
       webpack_version: latest
       job_part: test
-    - nodejs_version: '4.3'
+    - nodejs_version: '4.8'
       webpack_version: latest
       job_part: test
 build: 'off'
@@ -19,7 +19,7 @@ matrix:
   fast_finish: true
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm i -g npm@latest
+  - npm i -g npm@^5.0.0
   - npm install
 before_test:
   - cmd: npm install webpack@%webpack_version%


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

`npm --version` on CI fails

```
# npm --version gives
ERROR: npm is known not to run on Node.js v4.3.2
Node.js 4 is supported but the specific version you're running has
a bug known to break npm. Please update to at least 4.7.0 to use this
version of npm. You can find the latest release of Node.js at https://nodejs.org/
```

Eg: https://travis-ci.org/webpack-contrib/babel-minify-webpack-plugin/builds/290125106