### PR TITLE
docs(README): clarify defaults (`pluginOpts`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ module.exports = {
 + `comments`: Preserve Comments. Default: `/^\**!|@preserve|@license|@cc_on/`, falsy value to remove all comments. Accepts function, object with property test (regex), and values.
 + `sourceMap`: Configure a sourcemap style. Default: [webpackConfig.devtool](https://webpack.js.org/configuration/devtool/)
 + `parserOpts`: Configure babel with special parser options.
-+ `babel`: Pass in a custom babel-core instead. Default: `require("babel-core")`
-+ `minifyPreset`: Pass in a custom minify preset instead. Default: `require("babel-preset-minify")`
++ `babel`: Pass in a custom `babel-core` instead. Default: `require("babel-core")`
++ `minifyPreset`: Pass in a custom `babel-minify` preset instead. Default: `require("babel-preset-minify")`
 
 <h2 align="center">Why</h2>
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ module.exports = {
 
 + `test`: JS file extension regex. Default: `/\.js($|\?)/i`
 + `comments`: Preserve Comments. Default: `/^\**!|@preserve|@license|@cc_on/`, falsy value to remove all comments. Accepts function, object with property test (regex), and values.
-+ `sourceMap`: Default: uses [webpackConfig.devtool](https://webpack.js.org/configuration/devtool/). Set this to override that.
++ `sourceMap`: Configure a sourcemap style. Default: [webpackConfig.devtool](https://webpack.js.org/configuration/devtool/)
 + `parserOpts`: Configure babel with special parser options.
-+ `babel`: Pass in a custom babel-core instead. `require("babel-core")`
-+ `minifyPreset`: Pass in a custom minify preset instead - `require("babel-preset-minify")`.
++ `babel`: Pass in a custom babel-core instead. Default: `require("babel-core")`
++ `minifyPreset`: Pass in a custom minify preset instead. Default: `require("babel-preset-minify")`
 
 <h2 align="center">Why</h2>
 


### PR DESCRIPTION
It's not clear if these are the defaults or if they're examples of how the user could use something different. 
If they are just examples what are the defaults? (maybe undefined?)
I've made several pluginOpts more consistent in formatting and punctuation.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
