### PR TITLE
Add TypeScript declarations to support Webpack configurations written in TypeScript as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "node": ">= 4.3 < 5.0.0 || >= 5.10"
   },
   "main": "dist/cjs.js",
+  "types": "types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "types"
   ],
   "scripts": {
     "start": "npm run build -- -w",
@@ -36,6 +38,8 @@
     "webpack-sources": "^1.0.1"
   },
   "devDependencies": {
+    "@types/babel-core": "*",
+    "@types/webpack": "*",
     "babel-cli": "^6.24.1",
     "babel-jest": "^20.0.3",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,53 @@
+import { BabylonOptions } from 'babel-core';
+import { Plugin } from 'webpack';
+
+declare module 'babel-minify-webpack-plugin' {
+  export type BabelMinifyPluginOptionValue = boolean | { [k: string]: any };
+
+  export interface BabelMinifyOptions {
+    [k: string]: any;
+    booleans?: BabelMinifyPluginOptionValue;
+    builtIns?: BabelMinifyPluginOptionValue;
+    consecutiveAdds?: BabelMinifyPluginOptionValue;
+    deadcode?: BabelMinifyPluginOptionValue;
+    evaluate?: BabelMinifyPluginOptionValue;
+    flipComparisons?: BabelMinifyPluginOptionValue;
+    guards?: BabelMinifyPluginOptionValue;
+    infinity?: BabelMinifyPluginOptionValue;
+    keepClassName?: BabelMinifyPluginOptionValue;
+    keepFnName?: BabelMinifyPluginOptionValue;
+    mangle?: BabelMinifyPluginOptionValue;
+    memberExpressions?: BabelMinifyPluginOptionValue;
+    mergeVars?: BabelMinifyPluginOptionValue;
+    numericLiterals?: BabelMinifyPluginOptionValue;
+    propertyLiterals?: BabelMinifyPluginOptionValue;
+    regexpConstructors?: BabelMinifyPluginOptionValue;
+    removeConsole?: BabelMinifyPluginOptionValue;
+    removeDebugger?: BabelMinifyPluginOptionValue;
+    removeUndefined?: BabelMinifyPluginOptionValue;
+    replace?: BabelMinifyPluginOptionValue;
+    simplify?: BabelMinifyPluginOptionValue;
+    simplifyComparisons?: BabelMinifyPluginOptionValue;
+    tdz?: BabelMinifyPluginOptionValue;
+    typeConstructors?: BabelMinifyPluginOptionValue;
+    undefinedToVoid?: BabelMinifyPluginOptionValue;
+  }
+
+  export interface BabelMinifyPluginOptions {
+    test?: RegExp;
+    include?: string[];
+    exclude?: string[];
+    comments?: (contents: string) => boolean | RegExp | boolean;
+    sourceMap?: string;
+    parserOpts?: BabylonOptions;
+    babel?: any;
+    minifyPreset?: any;
+  }
+
+  export default class BabelMinifyPlugin extends Plugin {
+    constructor(
+        minifyOpts?: BabelMinifyOptions,
+        pluginOpts?: BabelMinifyPluginOptions
+    );
+  }
+}


### PR DESCRIPTION
This PR adds a simple start at hashing out the simpler parts of declaring TypeScript interfaces for consumers of `babel-minify-webpack-plugin`. This allows end-users to leverage this plugin in a TypeScript-authored Webpack config file:

```typescript
import { Plugin } from 'webpack';
import Minify from 'babel-minify-webpack-plugin';

const plugins: Plugin[] = [ new Minify() ];
```
There were a couple cases where the plugin was being extremely robust to support just about any value passed in as a fallback (typically via boolean coercion) that isn't explicitly listed in the types (otherwise they'd fall down to TypeScript's `any`). 

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
